### PR TITLE
fix build problem in macos m1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
     build:
       context: ./test_experiment
       dockerfile: Dockerfile
+      platforms:
+        - "linux/amd64"
     depends_on:
       - "mlflow"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       context: ./test_experiment
       dockerfile: Dockerfile
       platforms:
-        - "linux/amd64"
+        - "linux/amd64"  # once continuumio/miniconda3:latest image work on native aarch64 (arm), remove this line
     depends_on:
       - "mlflow"
     environment:


### PR DESCRIPTION
fix bug in https://github.com/Toumash/mlflow-docker/issues/24, by building `run_test_experiment` image to `linux/amd64` platforms.
So that the macos m1 can run the install normally but with some performance loss in test_experiment stage which I think it's doesn't matter.
Besides I alse run it in windows-docker desktop, to test it. And it run successfully also.